### PR TITLE
Various updates for reproducibility et al.

### DIFF
--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: Chromium version
+        required: true
 
 jobs:
   generate-tarball:
@@ -32,8 +38,8 @@ jobs:
           git config --global user.name "Chromium Bot"
           git config --global user.email "chromium@gentoo.org"
 
-      - name: Package Chromium tarballs for ${{ github.ref_name }}
-        run: ./package_chromium.sh ${{ github.ref_name }}
+      - name: Package Chromium tarballs for ${{ inputs.version || github.ref_name }}
+        run: ./package_chromium.sh ${{ inputs.version || github.ref_name }}
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4
@@ -42,7 +48,7 @@ jobs:
             path: out/
 
       - name: Notify success
-        if: success()
+        if: success() && github.event_name == 'push'
         uses: Gottox/irc-message-action@v2.1.3
         with:
           server: irc.libera.chat
@@ -52,7 +58,7 @@ jobs:
           message: "Successfully generated Chromium tarballs for ${{ github.ref_name }}"
 
       - name: Notify failure
-        if: failure()
+        if: failure() && github.event_name == 'push'
         uses: Gottox/irc-message-action@v2.1.3
         with:
           server: irc.libera.chat

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -7,9 +7,23 @@ on:
 
 jobs:
   generate-tarball:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
+      - name: Free up space on the runner
+        run: |
+          echo Before:
+          df -m .
+          sudo rm -rf \
+            /usr/local/.ghcup \
+            /usr/local/lib/android \
+            /usr/local/share/powershell \
+            /usr/share/dotnet \
+            /usr/share/swift \
+            "$AGENT_TOOLSDIRECTORY"
+          echo After:
+          df -m .
+
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/export_tarball.py
+++ b/export_tarball.py
@@ -17,10 +17,13 @@ import subprocess
 import sys
 import tarfile
 nonessential_dirs = (
+    'build/linux/debian_bullseye_amd64-sysroot',
+    'build/linux/debian_bullseye_i386-sysroot',
     'third_party/blink/tools',
     'third_party/blink/web_tests',
     'third_party/hunspell_dictionaries',
     'third_party/hunspell/tests',
+    'third_party/instrumented_libs',
     'third_party/jdk/current',
     'third_party/jdk/extras',
     'third_party/liblouis/src/tests/braille-specs',

--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -90,10 +90,10 @@ export_tarballs() {
 	clog "Exporting tarballs for version ${1}:"
 	clog "Exporting test data tarball"
 	./export_tarball.py --version --xz --test-data --remove-nonessential-files "chromium-${1}" --src-dir src/
-	mv "chromium-${1}.tar.xz" "out/chromium-${1}-testdata.tar.xz" || die "Failed to move test data tarball"
+	mv "chromium-${1}.tar.xz" "out/chromium-${1}-linux-testdata.tar.xz" || die "Failed to move test data tarball"
 	clog "Exporting main tarball"
 	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --src-dir src/
-	mv "chromium-${1}.tar.xz" "out/chromium-${1}.tar.xz" || die "Failed to move tarball"
+	mv "chromium-${1}.tar.xz" "out/chromium-${1}-linux.tar.xz" || die "Failed to move main tarball"
 }
 
 main() {

--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -73,6 +73,8 @@ run_hooks() {
 	touch src/chrome/test/data/webui/i18n_process_css_test.html
 	src/tools/update_pgo_profiles.py '--target=linux' update '--gs-url-base=chromium-optimization-profiles/pgo_profiles' ||
 		die "Failed to update PGO profiles"
+	src/v8/tools/builtins-pgo/download_profiles.py --force --check-v8-revision --depot-tools depot_tools download ||
+		die "Failed to download V8 PGO profiles"
 }
 
 # This function exports the tarballs for a given version of Chromium.
@@ -89,7 +91,7 @@ export_tarballs() {
 	clog "Exporting test data tarball"
 	./export_tarball.py --version --xz --test-data --remove-nonessential-files "chromium-${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}-testdata.tar.xz" || die "Failed to move test data tarball"
-	clog "Exporting Main tarball"
+	clog "Exporting main tarball"
 	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}.tar.xz" || die "Failed to move tarball"
 }
@@ -100,6 +102,9 @@ main() {
 	fi
 
 	local version="$1"
+
+	# Some Google Python scripts start with "#!/usr/bin/env python"
+	python --version 2>&1 | grep -q '^Python 3\.' || die "Python 3 must be accessible in the PATH as \"python\""
 
 	clog "Packaging Chromium version ${version}"
 

--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -94,6 +94,13 @@ export_tarballs() {
 	clog "Exporting main tarball"
 	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}-linux.tar.xz" || die "Failed to move main tarball"
+	clog "Generating hashes"
+	local hash tarball
+	for tarball in "chromium-${1}.tar.xz" "chromium-${1}-testdata.tar.xz"; do
+		for hash in md5 sha1 sha224 sha256 sha384 sha512; do
+			(cd out && echo "$hash  $(${hash}sum "$tarball")")
+		done > "out/$tarball.hashes"
+	done
 }
 
 main() {

--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -87,10 +87,10 @@ export_tarballs() {
 	fi
 	clog "Exporting tarballs for version ${1}:"
 	clog "Exporting test data tarball"
-	./export_tarball.py --version --xz --test-data --remove-nonessential-files "chromium-${1}" --progress --src-dir src/
+	./export_tarball.py --version --xz --test-data --remove-nonessential-files "chromium-${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}-testdata.tar.xz" || die "Failed to move test data tarball"
 	clog "Exporting Main tarball"
-	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --progress --src-dir src/
+	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}.tar.xz" || die "Failed to move tarball"
 }
 


### PR DESCRIPTION
Hello @Kangie,

I come to you from the Debian camp, and have a handful of commits here with the following improvements:

* Make tarball generation reproducible

* Allow this to run on a regular GitHub runner

* Include some [V8 PGO] files that are present in the Debian source tarball

* Compress the tar file as it's generated instead of first writing out the whole thing uncompressed

* File off some rough edges on the scripts

There are a couple questions I have for you, possible further changes to make:

* The `package_chromium.sh` script has this comment:
  ```
  # We suffix the tarball with -linux so that it doesn't conflict with
  # official tarballs, whenever they come out.
  ```
  This is not currently happening. Should this be added, or the comment removed?

* The `-testdata` tarball is under 100 kB. Is that typically the case? Why even have that separate?

* I see the tarball generation job has been failing lately. Is the self-hosted runner arm64 based? It's possible that running it on a normal (amd64) GH runner will sidestep whatever the problem is there.