### PR TITLE
Follow-on updates

### DIFF
--- a/export_tarball.py
+++ b/export_tarball.py
@@ -27,6 +27,7 @@ nonessential_dirs = (
     'third_party/jdk/current',
     'third_party/jdk/extras',
     'third_party/liblouis/src/tests/braille-specs',
+    'third_party/llvm-build',
     'third_party/xdg-utils/tests',
     'v8/test',
 )


### PR DESCRIPTION
There were a few bits I was working on before the commits went in last night (should've said something!) and I've collected them here.

I've been comparing the generated tarball against upstream's, with two rules that I think should apply:

1. Every file present in our tarball should match its counterpart in Google's exactly;
2.  Every file in Google's that is absent from ours should be covered by a short and intentional list of directory exclusions, without individual-file one-offs. (Excluding things that obviously need updating on their side, like all the `.pyc` files)

I noticed an issue with these two files:
```
third_party/llvm-build/force_head_revision
third_party/llvm-build/Release+Asserts/cr_build_revision
```
One is absent from our tarball, the other is empty (just a `\n`) while ours has a version string. Rather than try to suss out what was going on there, I added `third_party/llvm-build` to the nonessential dirs. That one's also pretty big, and none of us with a home distro need a third-party LLVM build anyway.

The one remaining missing file is `buildtools/linux64/clang-format`, a Python script which evidently comes from [here](https://chromium.googlesource.com/chromium/tools/build/+/refs/heads/main/recipes/recipe_modules/chromium/resources/clang-format). However, it's not clear what the logic is to get the exact right revision for a given Chromium version. This remains unaddressed.

I also updated the logic to get the GN commit in a way that will fail if the `--version` output doesn't match the expected pattern.

Also, print out the hashes, so they are recorded in the workflow log. The log will stick around for a lot longer than the `.hashes` files, so this will help anyone auditing the reproducibility.

The rest here is either polish, or (comment) documentation.