### PR TITLE
package_chromium.sh: Minor updates

### DIFF
--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -5,6 +5,7 @@
 source logging.sh
 
 set -e
+umask 022
 
 # This function clones the depot_tools repository from the Chromium project
 # and adds the depot_tools directory to the system PATH.
@@ -100,6 +101,7 @@ get_gn_sources() {
 	# Move GN sources to the tools/gn directory
 	find "${git_root}" -maxdepth 1 -mindepth 1 -not -name ".git" -not -name ".gitignore" -not -name ".linux-sysroot" -not -name "out" -print | while read -r f; do
 		basename=$(basename "$f")
+		rm -rf "$tools_gn/$basename"
 		mv "$f" "$tools_gn/$basename" || die "Failed to move $basename"
 	done
 
@@ -122,7 +124,7 @@ export_tarballs() {
 	fi
 	clog "Exporting tarballs for version ${1}:"
 	clog "Exporting test data tarball"
-	./export_tarball.py --version --xz --test-data --remove-nonessential-files "chromium-${1}" --src-dir src/
+	./export_tarball.py --version --xz --test-data "chromium-${1}" --src-dir src/
 	mv "chromium-${1}.tar.xz" "out/chromium-${1}-linux-testdata.tar.xz" || die "Failed to move test data tarball"
 	clog "Exporting main tarball"
 	./export_tarball.py --version --xz --remove-nonessential-files chromium-"${1}" --src-dir src/


### PR DESCRIPTION
A few additional improvements, after further testing:

* The umask affects the permissions of files in the tarballs, so set it to something normal in case it isn't;

* The `tools/gn/` directory was being populated incorrectly if I ran the process a second/third time;

* I found what was going on with the `-testdata` tarball: `--test-data` should not be used with `--remove-nonessential-files`. Google's invocation doesn't do this. The resulting tarball appears to be a match for Google's, modulo the file metadata.

In other news, I've prepared my updates to push to Google, though I'm going to wait until after the holiday weekend to get them in so they don't get lost in the rush. What I'll be sending them is a bit different than what I did here (e.g. instead of adding to `nonessential_dirs`, add to the list of directories in `export_lite_tarball()` in `publish_tarball.py`), but we could then consider checking out the containing Git repo and running `export_tarball.py` in there rather than maintaining a local copy.