### PR TITLE
Pin third-party GitHub actions by commit-hash for security

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -20,11 +20,6 @@ jobs:
           # If we don't set fetch-depth to 0, we won't be able to fetch tags
           fetch-depth: 0
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Get Chromium release info
         run: |
           curl --fail-with-body --max-time 30 --no-progress-meter -o releases.json \
@@ -78,7 +73,7 @@ jobs:
           git push --follow-tags
 
       - name: Update IRC (Stable)
-        uses: Gottox/irc-message-action@v2.1.5
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         if: steps.tag_versions.outputs.stable != ''
         with:
           server: irc.libera.chat
@@ -88,7 +83,7 @@ jobs:
           message: "New release: ${{ steps.tag_versions.outputs.stable }}"
 
       - name: Update IRC (Beta)
-        uses: Gottox/irc-message-action@v2.1.5
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         if: steps.tag_versions.outputs.beta != ''
         with:
           server: irc.libera.chat
@@ -98,7 +93,7 @@ jobs:
           message: "New release: ${{ steps.tag_versions.outputs.beta }}"
 
       - name: Update IRC (Dev)
-        uses: Gottox/irc-message-action@v2.1.5
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         if: steps.tag_versions.outputs.dev != ''
         with:
           server: irc.libera.chat

--- a/.github/workflows/tarballs.yml
+++ b/.github/workflows/tarballs.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Notify success
         if: success() && github.event_name == 'push'
-        uses: Gottox/irc-message-action@v2.1.3
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         with:
           server: irc.libera.chat
           notice: false
@@ -76,7 +76,7 @@ jobs:
 
       - name: Notify failure
         if: failure() && github.event_name == 'push'
-        uses: Gottox/irc-message-action@v2.1.3
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         with:
           server: irc.libera.chat
           notice: false
@@ -113,7 +113,7 @@ jobs:
 
       - name: Notify success
         if: success()
-        uses: Gottox/irc-message-action@v2.1.5
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         with:
           server: irc.libera.chat
           notice: false
@@ -123,7 +123,7 @@ jobs:
 
       - name: Notify failure
         if: failure()
-        uses: Gottox/irc-message-action@v2.1.5
+        uses: Gottox/irc-message-action@5ab60c2121053c99a383753390fb169a0045694d # v2.1.5
         with:
           server: irc.libera.chat
           notice: false


### PR DESCRIPTION
This implements the advice detailed here:

https://blog.rafaelgss.dev/why-you-should-pin-actions-by-commit-hash

https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide

https://julienrenaux.fr/2019/12/20/github-actions-security-risk/

Also drop the "Set up Python" step from the cron workflow as we no longer use the `get_chromium_versions.py` Python script.